### PR TITLE
Drop redundant filtering

### DIFF
--- a/server.js
+++ b/server.js
@@ -64,7 +64,7 @@ app.post('/', (req, res) => {
 		// Keep only the layer that is the one we're rendering OR 
 		// wasn't included in our list of passed layer IDs
 		styleClone.layers = styleClone.layers.filter(layer =>
-			layer.id == layerToKeep || !layers.includes(layer.id)
+			layer.id == layerToKeep
 		)
 		promises[index] = render(styleClone, width, height, { zoom, center, token: `${ACCESS_TOKEN}` })	
 	})


### PR DESCRIPTION
@ryanbateman it looks like _all_ layers are added to `styleClone` unless the `|| !layers.includes(layer.id)` line is dropped?